### PR TITLE
Added ability to mark annotations as selected

### DIFF
--- a/packages/canvas-panel-core/src/components/Annotation/Annotation.js
+++ b/packages/canvas-panel-core/src/components/Annotation/Annotation.js
@@ -19,6 +19,10 @@ type Props = {
   annotation: Manifesto.Annotation,
   bem: BemBlockType,
   style: { [string]: any },
+  bemModifiers: (
+    annotation: Manifesto.Annotation,
+    props: Props
+  ) => { [string]: boolean },
   onClick: (
     annotation: Manifesto.Annotation,
     vect: Vector,
@@ -42,8 +46,18 @@ class Annotation extends Component<Props> {
       : null;
 
   render() {
-    const { style, bem } = this.props;
-    return <div className={bem} style={style} onClick={this.handleClick} />;
+    const { style, bem, bemModifiers, annotation } = this.props;
+    const modifiers = bemModifiers
+      ? bemModifiers(annotation, this.props)
+      : null;
+
+    return (
+      <div
+        className={modifiers ? bem.modifiers(modifiers) : bem}
+        style={style}
+        onClick={this.handleClick}
+      />
+    );
   }
 }
 

--- a/packages/canvas-panel-core/src/components/AnnotationCanvasRepresentation/AnnotationCanvasRepresentation.js
+++ b/packages/canvas-panel-core/src/components/AnnotationCanvasRepresentation/AnnotationCanvasRepresentation.js
@@ -20,6 +20,7 @@ class AnnotationCanvasRepresentation extends Component {
       annotationStyle,
       growthStyle,
       onClickAnnotation,
+      bemModifiers,
       ...props
     } = this.props;
 
@@ -30,6 +31,7 @@ class AnnotationCanvasRepresentation extends Component {
             onClickAnnotation={onClickAnnotation}
             annotationStyle={annotationStyle}
             growthStyle={growthStyle}
+            bemModifiers={bemModifiers}
           />
         </AnnotationProvider>
       </AnnotationListProvider>

--- a/packages/canvas-panel-core/src/components/AnnotationDetail/AnnotationDetail.js
+++ b/packages/canvas-panel-core/src/components/AnnotationDetail/AnnotationDetail.js
@@ -13,6 +13,10 @@ type Props = {
 };
 
 class AnnotationDetail extends Component<Props> {
+  static defaultProps = {
+    closeText: 'close',
+  };
+
   render() {
     const { annotation, onClose, closeText, bem } = this.props;
     const resource = annotation.getResource();

--- a/packages/canvas-panel-core/src/components/AnnotationDetail/AnnotationDetail.md
+++ b/packages/canvas-panel-core/src/components/AnnotationDetail/AnnotationDetail.md
@@ -7,31 +7,45 @@ const animationSpeed = 1;
 initialState = { annotation: null, viewport: null };
 <div style={{ padding: 10 }}>
   <div style={{ width: 450, display: 'inline-block' }}>
-    <Manifest url={manifests.main}>
-      <CanvasProvider startCanvas={72}>
-        <Viewport
-          maxWidth={450}
-          setRef={v => {
-            viewport = v;
-          }}
-        >
-          <SingleTileSource viewportController={true}>
-            <OpenSeadragonViewport>
-              <OpenSeadragonViewer maxHeight={1000} />
-            </OpenSeadragonViewport>
-          </SingleTileSource>
-          <AnnotationCanvasRepresentation
-            ratio={0.1}
-            annotationStyle={{ outline: '2px solid purple' }}
-            growthStyle="fixed"
-            onClickAnnotation={(annotation, bounds) => {
-              setState({ annotation });
-              viewport.goToRect(bounds, 300, animationSpeed);
+    <Bem cssClassMap={{ annotation: 'annotation-detail-md-annotation' }}>
+      <Manifest url={manifests.main}>
+        <CanvasProvider startCanvas={72}>
+          <Viewport
+            maxWidth={450}
+            setRef={v => {
+              viewport = v;
             }}
-          />
-        </Viewport>
-      </CanvasProvider>
-    </Manifest>
+          >
+            <SingleTileSource viewportController={true}>
+              <OpenSeadragonViewport>
+                <OpenSeadragonViewer maxHeight={1000} />
+              </OpenSeadragonViewport>
+            </SingleTileSource>
+            <AnnotationCanvasRepresentation
+              ratio={0.1}
+              growthStyle="fixed"
+              bemModifiers={annotation => ({
+                selected: state.annotation
+                  ? state.annotation.id === annotation.id
+                  : null,
+              })}
+              onClickAnnotation={(annotation, bounds) => {
+                setState({ annotation });
+                viewport.goToRect(bounds, 300, animationSpeed);
+              }}
+            />
+          </Viewport>
+        </CanvasProvider>
+      </Manifest>
+    </Bem>
+    <style>{`
+      .annotation-detail-md-annotation {
+        outline: 2px solid purple;
+      }
+      .annotation-detail-md-annotation--selected {
+        outline: 2px solid orange;
+      }
+      `}</style>
   </div>
   <div style={{ width: 300, display: 'inline-block', padding: 30 }}>
     {state.annotation ? (

--- a/packages/canvas-panel-core/src/components/AnnotationRepresentation/AnnotationRepresentation.js
+++ b/packages/canvas-panel-core/src/components/AnnotationRepresentation/AnnotationRepresentation.js
@@ -9,6 +9,7 @@ class AnnotationRepresentation extends Component {
       onClickAnnotation,
       annotationStyle,
       growthStyle,
+      bemModifiers,
       ...props
     } = this.props;
     return (
@@ -24,6 +25,7 @@ class AnnotationRepresentation extends Component {
             style={annotationStyle}
             onClick={onClickAnnotation}
             growthStyle={growthStyle}
+            bemModifiers={bemModifiers}
           />
         ))}
       </CanvasRepresentation>

--- a/packages/canvas-panel-core/src/components/Bem/Bem.js
+++ b/packages/canvas-panel-core/src/components/Bem/Bem.js
@@ -14,6 +14,7 @@ const defaultContext = {
 export type BemBlockType = {
   element(name: string): BemElementType | string,
   modifier(name: string): BemBlockType | string,
+  modifiers({ [string]: boolean }): BemBlockType | string,
 };
 
 export type BemElementType = {

--- a/packages/canvas-panel-patchwork-plugin/Patchwork.css
+++ b/packages/canvas-panel-patchwork-plugin/Patchwork.css
@@ -30,6 +30,7 @@
 }
 
 .patchwork-annotation-pin:before {
+  cursor: pointer;
   pointer-events: initial;
   content: '+';
   position: absolute;
@@ -46,6 +47,12 @@
   line-height: 28px;
 }
 
+.patchwork-annotation-pin--selected:before {
+  content: '×';
+  background: #000;
+  color: #fff;
+}
+
 .patchwork-annotation-pin:after {
   content: '';
   position: absolute;
@@ -57,6 +64,11 @@
   top: 9px;
   text-align: center;
   line-height: 28px;
+}
+
+.patchwork-annotation-pin--selected:after {
+  background: #000;
+  color: #fff;
 }
 
 .patchwork-container {

--- a/packages/canvas-panel-patchwork-plugin/demo.html
+++ b/packages/canvas-panel-patchwork-plugin/demo.html
@@ -14,7 +14,7 @@
 <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
 <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.3.1/openseadragon.min.js"></script>
 <script crossorigin src="https://cdn.rawgit.com/stephenwf/manifesto/feature/p3-alpha/dist/client/manifesto.js"></script>
-<script src="./umd/canvas-panel-patchwork-plugin.min.js"></script>
+<script src="./umd/@canvas-panel/patchwork-plugin.min.js"></script>
 <script>
   singleCanvasAnnotationDetailViewer.help();
 

--- a/packages/canvas-panel-patchwork-plugin/src/index.js
+++ b/packages/canvas-panel-patchwork-plugin/src/index.js
@@ -33,6 +33,7 @@ const defaultConfiguration = {
   growthStyle: 'fixed',
   closeText: '×',
   relativeContainer: true,
+  clickToClose: true,
 };
 
 class Main extends Component {
@@ -47,7 +48,16 @@ class Main extends Component {
   setViewport = viewport => (this.viewport = viewport);
 
   onClickAnnotation = (annotation, bounds) => {
+    const { clickToClose } = this.props;
     this.dispatch('onClickAnnotation', { annotation, bounds });
+
+    if (
+      clickToClose &&
+      (this.state.annotation && this.state.annotation.id === annotation.id)
+    ) {
+      return this.onClose();
+    }
+
     this.setState({ annotation });
     this.viewport.goToRect(
       bounds,
@@ -117,6 +127,11 @@ class Main extends Component {
                 </SingleTileSource>
                 <AnnotationCanvasRepresentation
                   growthStyle={growthStyle}
+                  bemModifiers={annotation => ({
+                    selected: state.annotation
+                      ? state.annotation.id === annotation.id
+                      : null,
+                  })}
                   onClickAnnotation={this.onClickAnnotation}
                 />
               </Viewport>


### PR DESCRIPTION
Added the ability to add modifiers to annotations that you can use to mark annotations as in a different state. The interface is:

```
function bemModifiers(annotation: Manifesto.Annotation, props) : { [string]: sting }
```

When you pass this `bemModifiers` prop to an annotation component (or HOC) the function should return modifiers as per [BEM-js](https://github.com/digirati-co-uk/bem-js).

In short:
```
{
  'something': true,
  'something-else': somebool === true,
  'something-false': false,
}
```

when thats passed to a component with the block name `annotation`, the following css classes will be applied:
```
<div class="annotation annotation--something annotation--something-else" />
```

When the state changes, your BEM modifiers will be called again. Currently this is not memorised, but it should be a quick, inexpensive (and pure) function to call.

The use case currently is marking annotations in a "selected" state. But this could also be used to group annotations, or highlight multiple annotations. It could also change css properties based on the content of the annotation itself (motivation for example).