### PR TITLE
Added fullscreen classnames

### DIFF
--- a/packages/canvas-panel-patchwork-plugin/src/index.js
+++ b/packages/canvas-panel-patchwork-plugin/src/index.js
@@ -163,6 +163,24 @@ class PatchworkPlugin extends Component {
 
   setRef = ref => (this.ref = ref);
 
+  getClasses({ fullscreenEnabled, isFullscreen, isMobileFullscreen }) {
+    const classNames = [];
+    if (fullscreenEnabled) {
+      classNames.push('fullscreen-available');
+    }
+    if (isFullscreen) {
+      classNames.push('fullscreen-native-enabled');
+    }
+    if (isMobileFullscreen) {
+      classNames.push('fullscreen-mobile-enabled');
+    }
+    if (isFullscreen || isMobileFullscreen) {
+      classNames.push('fullscreen-active');
+    }
+
+    return classNames;
+  }
+
   render() {
     const {
       manifest,
@@ -195,6 +213,11 @@ class PatchworkPlugin extends Component {
         <Fullscreen>
           {({ isFullscreen, fullscreenEnabled, toggleFullscreen }) => (
             <div
+              className={this.getClasses({
+                fullscreenEnabled,
+                isFullscreen,
+                isMobileFullscreen: this.state.isMobileFullscreen,
+              }).join(' ')}
               style={{ zIndex: this.state.isMobileFullscreen ? '10000' : null }}
             >
               <Bem cssClassMap={cssClassMap} prefix={cssClassPrefix}>


### PR DESCRIPTION
Hi @atiro I've added some descriptive fullscreen class names so you can target the different fullscreen options we've made available.

- `fullscreen-available` lets us know that it might go fullscreen.
- `fullscreen-native-enabled ` this is when there is a native fullscreen (most likely desktop)
- `fullscreen-mobile-enabled ` this is when there is a mobile pseudo-fullscreen enabled.
- `fullscreen-active ` this is catch-all for both types of fullscreen.


Hopefully thats enough to describe some different styling for the fullscreen and non-fullscreen versions! All of the components should be "under" these class names so:

```
.fullscreen-native-enabled .something {
 // ....
}
```

should work fine.