### PR TITLE
V&A Feedback

### DIFF
--- a/packages/canvas-panel-core/styleguide.config.js
+++ b/packages/canvas-panel-core/styleguide.config.js
@@ -1,8 +1,9 @@
 var path = require('path');
 var createNwbWebpackConfig = require('create-nwb-webpack-config');
-
+var wpCgf = createNwbWebpackConfig();
+delete wpCgf.optimization;
 module.exports = {
-  webpackConfig: createNwbWebpackConfig(),
+  webpackConfig: wpCgf,
   previewDelay: 1000,
   context: {
     manifests: path.resolve(__dirname, 'config/manifests.js'),

--- a/packages/canvas-panel-slideshow/src/components/MobilePageView/MobilePageView.js
+++ b/packages/canvas-panel-slideshow/src/components/MobilePageView/MobilePageView.js
@@ -83,14 +83,30 @@ class MobilePageView extends Component {
     this.viewport.zoomIn();
   };
 
+  componentDidUpdate(prevProps) {
+    // only scroll into view if the active item changed last render
+    if (!this.state.isFullscreen) {
+      this.ensureActiveItemVisible();
+    }
+  }
+
+  ensureActiveItemVisible = () => {
+    if (this.activeItem) {
+      this.activeItem.scrollIntoView();
+    }
+  };
+
+  setActiveRef = element => {
+    this.activeItem = element;
+  };
+
   render() {
     const { isFullscreen, offset, down, open } = this.state;
-    const { bem, manifest } = this.props;
+    const { currentIndex, bem, manifest } = this.props;
 
     if (isFullscreen) {
       const {
         canvas,
-        currentIndex,
         nextRange,
         previousRange,
         getNextRange,
@@ -147,7 +163,10 @@ class MobilePageView extends Component {
               canvas={canvas}
             >
               {({ label, body, attributionLabel, attribution }) => (
-                <div className={bem.element('canvas')}>
+                <div
+                  ref={canvasIndex === currentIndex && this.setActiveRef}
+                  className={bem.element('canvas')}
+                >
                   <StaticImageViewport
                     className={bem.element('canvas-image')}
                     manifest={manifest}

--- a/packages/canvas-panel-slideshow/src/components/MobileViewer/MobileViewer.js
+++ b/packages/canvas-panel-slideshow/src/components/MobileViewer/MobileViewer.js
@@ -67,7 +67,7 @@ const ExitFullscreen = ({ bem, hidden, onClick }) => (
     onClick={onClick}
   >
     <ExitFullscreenIcon className={bem.element('exit-fullscreen-icon')} />
-    exit fullscreen
+    Exit slideshow
   </div>
 );
 

--- a/packages/canvas-panel-slideshow/src/components/MobileViewer/MobileViewer.scss
+++ b/packages/canvas-panel-slideshow/src/components/MobileViewer/MobileViewer.scss
@@ -27,6 +27,7 @@
     transition: opacity 0.2s;
     animation: fadein 0.6s;
     z-index: 12;
+    max-width: calc(100vw - 90px);
     & * {
       line-height: 1.4;
       color: white;


### PR DESCRIPTION
Changes: 
- [X] On mobile, 'Exit slideshow' label is being used instead of 'exit fullscreen'.

- [X] fixed mobile attribution copy max-width, it cannot reach the (i) icon on the right side.

- [X] scroll into view on exit fullscreen