### PR TITLE
Multi thumbnail collage

### DIFF
--- a/packages/canvas-panel-core/src/components/MultipleTileSources/MultipleTileSources.js
+++ b/packages/canvas-panel-core/src/components/MultipleTileSources/MultipleTileSources.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes, { any } from 'prop-types';
+import functionOrMapChildren from '../../utility/functionOrMapChildren';
+
+const MultipleTileSources = ({
+  canvas,
+  children,
+  annotationFilter,
+  ...props
+}) =>
+  functionOrMapChildren(children, {
+    props,
+    canvas,
+    visibleAnnotations: (canvas.__jsonld.items || []).reduce(
+      (_annotations, annotationPage) => {
+        _annotations = _annotations.concat(
+          (annotationPage.items || [])
+            .filter(resource => resource.type === 'Annotation')
+            .filter(annotationFilter)
+        );
+        return _annotations;
+      },
+      []
+    ),
+  });
+
+MultipleTileSources.propTypes = {
+  children: PropTypes.func.isRequired,
+  canvas: PropTypes.object.isRequired,
+  annotationFilter: PropTypes.func,
+};
+
+MultipleTileSources.defaultProps = {
+  annotationFilter: () => true,
+};
+
+export default MultipleTileSources;

--- a/packages/canvas-panel-core/src/index.js
+++ b/packages/canvas-panel-core/src/index.js
@@ -9,6 +9,7 @@ import CanvasNavigation from './components/CanvasNavigation/CanvasNavigation';
 import CanvasRepresentation from './components/CanvasRepresentation/CanvasRepresentation';
 import Fullscreen from './components/Fullscreen/Fullscreen';
 import SingleTileSource from './components/SingleTileSource/SingleTileSource';
+import MultipleTileSources from './components/MultipleTileSources/MultipleTileSources';
 import ObservableElement from './components/ObservableElement/ObservableElement';
 import AnnotationListProvider from './manifesto/AnnotationListProvider/AnnotationListProvider';
 import AnnotationProvider from './manifesto/AnnotationProvider/AnnotationProvider';
@@ -21,7 +22,7 @@ import OpenSeadragonViewport from './viewers/OpenSeadragonViewport/OpenSeadragon
 import SizedViewport from './viewers/SizedViewport/SizedViewport';
 import StaticImageViewport from './viewers/StaticImageViewport/StaticImageViewport';
 import Viewport from './viewers/Viewport/Viewport';
-import CanvasPosterViewport from './viewers/CanvasPosterViewport';
+import CanvasPosterViewport from './viewers/CanvasPosterViewport/CanvasPosterViewport';
 import functionOrMapChildren from './utility/functionOrMapChildren';
 import AnnotationSelector from './utility/AnnotationSelector';
 import htmlElementObserver from './utility/htmlElementObserver';

--- a/packages/canvas-panel-core/src/index.js
+++ b/packages/canvas-panel-core/src/index.js
@@ -21,6 +21,7 @@ import OpenSeadragonViewport from './viewers/OpenSeadragonViewport/OpenSeadragon
 import SizedViewport from './viewers/SizedViewport/SizedViewport';
 import StaticImageViewport from './viewers/StaticImageViewport/StaticImageViewport';
 import Viewport from './viewers/Viewport/Viewport';
+import CanvasPosterViewport from './viewers/CanvasPosterViewport';
 import functionOrMapChildren from './utility/functionOrMapChildren';
 import AnnotationSelector from './utility/AnnotationSelector';
 import htmlElementObserver from './utility/htmlElementObserver';
@@ -38,6 +39,7 @@ export {
   CanvasRepresentation,
   Fullscreen,
   SingleTileSource,
+  MultipleTileSources,
   ObservableElement,
   // Manifesto
   AnnotationListProvider,
@@ -53,6 +55,7 @@ export {
   SizedViewport,
   StaticImageViewport,
   Viewport,
+  CanvasPosterViewport,
   // Utils
   AnnotationSelector,
   Responsive,

--- a/packages/canvas-panel-core/src/viewers/CanvasPosterViewport/CanvasPosterViewport.js
+++ b/packages/canvas-panel-core/src/viewers/CanvasPosterViewport/CanvasPosterViewport.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import LocaleString from '../../manifesto/LocaleString/LocaleString';
+import AnnotationSelector from '../../utility/AnnotationSelector';
+
+class CanvasPosterViewport extends React.Component {
+  getXYWHCanvasRelative = (annotation, width, height) => {
+    const asSelector = AnnotationSelector.parse(annotation.target);
+    if (!asSelector || asSelector.source === asSelector.id) {
+      return {
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      };
+    }
+    if (asSelector.selector.unit === 'pixel') {
+      return {
+        top: (asSelector.selector.x / width) * 100 + '%',
+        left: (asSelector.selector.y / height) * 100 + '%',
+        width: (asSelector.selector.width / width) * 100 + '%',
+        height: (asSelector.selector.height / height) * 100 + '%',
+      };
+    } else if (asSelector.selector.unit === 'percent') {
+      return {
+        top: asSelector.selector.x + '%',
+        left: asSelector.selector.y + '%',
+        width: asSelector.selector.width + '%',
+        height: asSelector.selector.height + '%',
+      };
+    }
+  };
+
+  render() {
+    const { canvas, zoom, visibleAnnotations } = this.props;
+    const { width, height } = canvas.__jsonld;
+
+    return (
+      <div
+        style={{
+          width: (this.props.width || width) * zoom,
+          height: (this.props.height || height) * zoom,
+          position: 'relative',
+          background: 'lightgray',
+        }}
+      >
+        {visibleAnnotations.map(annotation =>
+          annotation.thumbnail ? (
+            <img
+              key={`annotation_el_${annotation.id}`}
+              src={annotation.thumbnail[0].id}
+              style={{
+                position: 'absolute',
+                ...this.getXYWHCanvasRelative(annotation, width, height),
+              }}
+            />
+          ) : (
+            <div
+              key={`annotation_el_${annotation.id}`}
+              style={{
+                position: 'absolute',
+                border: '2px dashed red',
+                ...this.getXYWHCanvasRelative(annotation, width, height),
+              }}
+            >
+              <LocaleString>{annotation.label}</LocaleString>
+            </div>
+          )
+        )}
+      </div>
+    );
+  }
+}
+
+CanvasPosterViewport.defaultProps = {
+  zoom: 0.2,
+};
+
+export default CanvasPosterViewport;

--- a/packages/canvas-panel-core/src/viewers/CanvasPosterViewport/CanvasPosterViewport.md
+++ b/packages/canvas-panel-core/src/viewers/CanvasPosterViewport/CanvasPosterViewport.md
@@ -1,0 +1,35 @@
+## Multiple Painting Annotations on a Single Canvas as a Thumbnail
+
+```js
+<Manifest url="https://adam-digirati.github.io/multi-tile-source.json">
+  <CanvasProvider startCanvas={0}>
+    {({ canvas, ...props }) => {
+      return (
+        <MultipleTileSources
+          annotationFilter={annotation => annotation.motivation === 'painting'}
+          canvas={canvas}
+        >
+          <CanvasPosterViewport canvas={canvas} />
+        </MultipleTileSources>
+      );
+    }}
+  </CanvasProvider>
+</Manifest>
+```
+
+```js
+<Manifest url="https://adam-digirati.github.io/balenciaga1.json">
+  <CanvasProvider startCanvas={0}>
+    {({ canvas, ...props }) => {
+      return (
+        <MultipleTileSources
+          annotationFilter={annotation => annotation.motivation === 'painting'}
+          canvas={canvas}
+        >
+          <CanvasPosterViewport canvas={canvas} />
+        </MultipleTileSources>
+      );
+    }}
+  </CanvasProvider>
+</Manifest>
+```


### PR DESCRIPTION
As a prequel for the multi-tile source full-featured viewer, this pull request aims to render a static thumbnail composite of these resources.

**DEMO:**

https://deploy-preview-371--canvas-panel.netlify.com/styleguide/#canvasposterviewport

**Features:**
- [x] renders regular images
- [x] renders video thumbnail images
- [x] renders text annotations with motivation painting, both text and HTML
- [x] handles positioning on the canvas
- [ ] handles cropping
- [ ] the rendered resources individually clickable

**Maybe features:**
- [ ] canvas rendering/single image rendering

**Thumbnail retrieval and cropping logic:**
- thumbnail service sizes closest to the final `width`/`height`
  - if the sizes embedded inline, use that
  - if not request for the info.json
- image service sizes closest to the final `width`/height
  - if the sizes embedded inline, use that
  - if not request for the info.json
- if no image received present a placeholder?
- if server-side cropping has no effect, apply client-side cropping:
  - using negative margins on the `HTML` version
  - drawImage 8 parameter version for the canvas renderer