### PR TITLE
Updated manifesto

### DIFF
--- a/packages/canvas-panel-cookbook/package.json
+++ b/packages/canvas-panel-cookbook/package.json
@@ -21,7 +21,7 @@
     "@canvas-panel/full-page-plugin": "0.1.1",
     "@canvas-panel/patchwork-plugin": "0.1.1",
     "@canvas-panel/slideshow": "0.1.1",
-    "@stephenwf-forks/manifesto.js": "2.2.25",
+    "manifesto.js": "git://github.com/stephenwf/manifesto.git#feature/p3-alpha-3",
     "bezier-easing": "2.1.0",
     "brace": "0.11.1",
     "classnames": "2.2.6",

--- a/packages/canvas-panel-cookbook/src/pages/AnnotationPlayground/AnnotationPlayground.js
+++ b/packages/canvas-panel-cookbook/src/pages/AnnotationPlayground/AnnotationPlayground.js
@@ -3,7 +3,7 @@ import 'brace';
 import 'brace/mode/json';
 import 'brace/theme/tomorrow_night_eighties';
 import AceEditor from 'react-ace';
-import Manifesto from '@stephenwf-forks/manifesto.js';
+import Manifesto from 'manifesto.js';
 import {
   Manifest,
   CanvasProvider,

--- a/packages/canvas-panel-core/package.json
+++ b/packages/canvas-panel-core/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fesk/bem-js": "^1.0.0",
     "@iiif/manifold": "^1.2.19",
-    "@stephenwf-forks/manifesto.js": "2.2.25",
+    "manifesto.js": "git://github.com/stephenwf/manifesto.git#feature/p3-alpha-3",
     "core-js": "^2.5.3",
     "create-react-context": "^0.2.0",
     "detect-it": "^3.0.5",

--- a/packages/canvas-panel-core/src/components/Annotation/Annotation.js
+++ b/packages/canvas-panel-core/src/components/Annotation/Annotation.js
@@ -3,7 +3,7 @@
  */
 
 import React, { Component } from 'react';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import { withBemClass } from '../Bem/Bem';
 import type { BemBlockType } from '../Bem/Bem';
 

--- a/packages/canvas-panel-core/src/components/AnnotationDetail/AnnotationDetail.js
+++ b/packages/canvas-panel-core/src/components/AnnotationDetail/AnnotationDetail.js
@@ -2,7 +2,7 @@
  * @flow
  */
 import React, { Component } from 'react';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import { withBemClass, type BemBlockType } from '../Bem/Bem';
 
 type Props = {

--- a/packages/canvas-panel-core/src/components/CanvasRepresentation/CanvasRepresentation.js
+++ b/packages/canvas-panel-core/src/components/CanvasRepresentation/CanvasRepresentation.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 
 class CanvasRepresentation extends Component {
   static propTypes = {

--- a/packages/canvas-panel-core/src/components/SingleTileSource/SingleTileSource.js
+++ b/packages/canvas-panel-core/src/components/SingleTileSource/SingleTileSource.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import getDataUriFromCanvas from '../../utility/getDataUriFromCanvas';
 import functionOrMapChildren, {
   FunctionOrMapChildrenType,

--- a/packages/canvas-panel-core/src/manifesto/AnnotationListProvider/AnnotationListProvider.js
+++ b/packages/canvas-panel-core/src/manifesto/AnnotationListProvider/AnnotationListProvider.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import functionOrMapChildren, {
   FunctionOrMapChildrenType,
 } from '../../utility/functionOrMapChildren';

--- a/packages/canvas-panel-core/src/manifesto/AnnotationProvider/AnnotationProvider.js
+++ b/packages/canvas-panel-core/src/manifesto/AnnotationProvider/AnnotationProvider.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import { FunctionOrMapChildrenType } from '../../utility/functionOrMapChildren';
 import functionOrMapChildren from '../../utility/functionOrMapChildren';
 import parseSelectorTarget from '../../utility/parseSelectorTarget';

--- a/packages/canvas-panel-core/src/manifesto/CanvasProvider/CanvasProvider.js
+++ b/packages/canvas-panel-core/src/manifesto/CanvasProvider/CanvasProvider.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import LocaleString from '../LocaleString/LocaleString';
 import functionOrMapChildren, {
   FunctionOrMapChildrenType,

--- a/packages/canvas-panel-core/src/manifesto/LocaleString/LocaleString.js
+++ b/packages/canvas-panel-core/src/manifesto/LocaleString/LocaleString.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import * as PropTypes from 'prop-types';
 
 class LocaleString extends PureComponent {
@@ -10,13 +10,13 @@ class LocaleString extends PureComponent {
     }
 
     if (Array.isArray(children)) {
-      return Manifesto.TranslationCollection.getValue(children);
+      return Manifesto.LanguageMap.getValue(children);
     }
 
     if (children[lang]) {
       return renderList
         ? renderList(children[lang])
-        : Manifesto.TranslationCollection.getValue(children[lang]);
+        : Manifesto.LanguageMap.getValue(children[lang]);
     }
 
     const values = Object.values(children);

--- a/packages/canvas-panel-core/src/manifesto/Manifest/Manifest.js
+++ b/packages/canvas-panel-core/src/manifesto/Manifest/Manifest.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import * as PropTypes from 'prop-types';
 import functionOrMapChildren, {
   FunctionOrMapChildrenType,

--- a/packages/canvas-panel-core/src/manifesto/RangeNavigationProvider/RangeNavigationProvider.js
+++ b/packages/canvas-panel-core/src/manifesto/RangeNavigationProvider/RangeNavigationProvider.js
@@ -2,7 +2,7 @@
  * @flow
  */
 import React, { Component } from 'react';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import functionOrMapChildren from '../../utility/functionOrMapChildren';
 import extractCanvasAndRegionsFromRange from '../../utility/extractCanvasAndRegionsFromRange';
 

--- a/packages/canvas-panel-core/src/manifesto/SearchProvider/SearchProvider.js
+++ b/packages/canvas-panel-core/src/manifesto/SearchProvider/SearchProvider.js
@@ -2,7 +2,7 @@
  * @flow
  */
 import React, { Component } from 'react';
-import Manifesto from '@stephenwf-forks/manifesto.js';
+import Manifesto from 'manifesto.js';
 import functionOrMapChildren from '../../utility/functionOrMapChildren';
 import SearchResults from '../../utility/SearchResults';
 

--- a/packages/canvas-panel-core/src/utility/SearchResults.js
+++ b/packages/canvas-panel-core/src/utility/SearchResults.js
@@ -1,7 +1,7 @@
 /**
  * @flow
  */
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import AnnotationSelector from './AnnotationSelector';
 
 type SearchResource = string;

--- a/packages/canvas-panel-core/src/utility/extractCanvasAndRegionsFromRange.js
+++ b/packages/canvas-panel-core/src/utility/extractCanvasAndRegionsFromRange.js
@@ -1,7 +1,7 @@
 /**
  * @flow
  */
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import parseSelectorTarget from './parseSelectorTarget';
 
 type Region = {

--- a/packages/canvas-panel-core/src/utility/getDataUriFromCanvas.js
+++ b/packages/canvas-panel-core/src/utility/getDataUriFromCanvas.js
@@ -1,4 +1,4 @@
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 import Manifold from './Manifold';
 
 function getDataUriFromImages(images) {

--- a/packages/canvas-panel-core/src/viewers/StaticImageViewport/StaticImageViewport.js
+++ b/packages/canvas-panel-core/src/viewers/StaticImageViewport/StaticImageViewport.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
-import * as Manifesto from '@stephenwf-forks/manifesto.js';
+import * as Manifesto from 'manifesto.js';
 
 class StaticImageViewport extends Component {
   state = { dragging: false };

--- a/packages/canvas-panel-redux/package.json
+++ b/packages/canvas-panel-redux/package.json
@@ -28,11 +28,11 @@
     "redux-saga": "^0.16.0"
   },
   "peerDependencies": {
-    "manifesto.js": "git://github.com/stephenwf/manifesto.git#0bd82b210d0247537c30a1d78532c00e32fa5fa1",
+    "manifesto.js": "git://github.com/stephenwf/manifesto.git#feature/p3-alpha-3",
     "react": "16.x"
   },
   "devDependencies": {
-    "manifesto.js": "git://github.com/stephenwf/manifesto.git#0bd82b210d0247537c30a1d78532c00e32fa5fa1",
+    "manifesto.js": "git://github.com/stephenwf/manifesto.git#feature/p3-alpha-3",
     "nwb": "0.23.0",
     "react": "16.6.3",
     "react-dom": "16.6.3"

--- a/packages/canvas-panel-search/package.json
+++ b/packages/canvas-panel-search/package.json
@@ -24,7 +24,7 @@
     "@canvas-panel/redux": "0.1.1",
     "@fesk/bem-js": "^1.0.0",
     "immutability-helper": "^2.6.4",
-    "manifesto.js": "git://github.com/stephenwf/manifesto.git#0bd82b210d0247537c30a1d78532c00e32fa5fa1",
+    "manifesto.js": "git://github.com/stephenwf/manifesto.git#feature/p3-alpha-3",
     "manifold": "git://github.com/IIIF-Commons/manifold.git#v1.2.16",
     "material-components-web": "^0.42.0",
     "rheostat": "^3.0.0"

--- a/packages/canvas-panel-slideshow/src/components/SimpleSlideTransition/SimpleSlideTransition.js
+++ b/packages/canvas-panel-slideshow/src/components/SimpleSlideTransition/SimpleSlideTransition.js
@@ -4,19 +4,30 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import './SimpleSlideTransition.scss';
 
 class SimpleSlideTransition extends Component {
+  scroll = window.scrollY;
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    if (nextProps.id !== this.props.id) {
+      this.scroll = window.scrollY;
+    }
+  }
+
+  setScroll = () => {
+    window.scrollTo(0, this.scroll);
+  };
+
   render() {
     const { children, id, bem, timeout = 500 } = this.props;
+
     return (
-      <TransitionGroup className={bem}>
+      <TransitionGroup className={bem} onExiting={this.setScroll}>
         <CSSTransition
           key={id}
-          timeout={{
-            enter: 1000,
-            exit: 1000,
-          }}
+          timeout={timeout}
           classNames="fade"
+          onExiting={this.setScroll}
         >
-          {children}
+          <div style={{ height: '750px', width: '100%' }}>{children}</div>
         </CSSTransition>
       </TransitionGroup>
     );

--- a/packages/canvas-panel-slideshow/src/components/SimpleSlideTransition/SimpleSlideTransition.scss
+++ b/packages/canvas-panel-slideshow/src/components/SimpleSlideTransition/SimpleSlideTransition.scss
@@ -2,16 +2,20 @@
   width: 100%;
   height: 100%;
 }
+
 .fade-enter {
   opacity: 0.01;
 }
+
 .fade-enter-active {
   opacity: 1;
   transition: opacity 500ms ease-in-out;
 }
+
 .fade-exit {
   opacity: 1;
 }
+
 .fade-exit-active {
   opacity: 0.01;
   transition: opacity 500ms ease-in-out;

--- a/packages/canvas-panel-slideshow/src/components/Slideshow/SlideShow.js
+++ b/packages/canvas-panel-slideshow/src/components/Slideshow/SlideShow.js
@@ -39,7 +39,9 @@ class SlideShow extends Component {
   }
 
   setSize = () => {
-    this.setState({ innerWidth: window.innerWidth });
+    this.setState({
+      innerWidth: window.innerWidth,
+    });
   };
 
   qualifiesForMobile = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,15 +593,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@stephenwf-forks/manifesto.js@2.2.25":
-  version "2.2.25"
-  resolved "https://registry.yarnpkg.com/@stephenwf-forks/manifesto.js/-/manifesto.js-2.2.25.tgz#69a7251479648c4078dc439c33dcbb2384916567"
-  integrity sha512-tvPoxY9xkhKPNtU39HKb2UAkq8n0RqYzHA4uaAwy0blKS8T3Ba5zEFSvstnNe7MSQkPL2UkkFsmDOaipg8sNXw==
-  dependencies:
-    exjs BSick7/exjs#0.5.0
-    http-status-codes edsilv/http-status-codes#v0.0.7
-    request "^2.83.0"
-
 "@types/jest@23.3.10":
   version "23.3.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
@@ -8334,12 +8325,13 @@ mamacro@^0.0.3:
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
   integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
 
-"manifesto.js@git://github.com/stephenwf/manifesto.git#0bd82b210d0247537c30a1d78532c00e32fa5fa1":
-  version "2.2.10"
-  resolved "git://github.com/stephenwf/manifesto.git#0bd82b210d0247537c30a1d78532c00e32fa5fa1"
+"manifesto.js@git://github.com/stephenwf/manifesto.git#feature/p3-alpha-3":
+  version "3.0.9"
+  resolved "git://github.com/stephenwf/manifesto.git#e7450b33c4d7b6325bb2e22b7b7082056fd35362"
   dependencies:
     exjs BSick7/exjs#0.5.0
     http-status-codes edsilv/http-status-codes#v0.0.7
+    request "^2.83.0"
 
 "manifold@git://github.com/IIIF-Commons/manifold.git#v1.2.16":
   version "1.2.16"


### PR DESCRIPTION
If you are using Canvas Panel, and Manifesto, you will need to use our fork of Manifesto for the time being. You can add this to your `package.json` to ensure it's the version chosen.
```
"manifesto.js": "git://github.com/stephenwf/manifesto.git#feature/p3-alpha-3",
```

You can see the missing pieces in Manifesto that would allow us to use an official Manifesto list here: 
https://github.com/stephenwf/manifesto/pull/4

