### PR TITLE
Fixed range highlight spacing

### DIFF
--- a/packages/canvas-panel-search/src/components/RangeHighlights/RangeHighlights.scss
+++ b/packages/canvas-panel-search/src/components/RangeHighlights/RangeHighlights.scss
@@ -5,8 +5,8 @@ $range-colour: #018786 !default;
   display: flex;
   width: 100%;
   padding-top: 5px;
-  margin-left: 20px;
-  margin-right: 20px;
+  margin-left: 3px;
+  margin-right: 3px;
   box-sizing: border-box;
   height: 20px;
 


### PR DESCRIPTION
Before:
<img width="885" alt="screenshot 2018-12-11 at 11 53 02" src="https://user-images.githubusercontent.com/8266711/49798932-773a3000-fd3b-11e8-9c66-716f17a0e12a.png">


After:
<img width="886" alt="screenshot 2018-12-11 at 11 52 43" src="https://user-images.githubusercontent.com/8266711/49798941-7d301100-fd3b-11e8-8d99-8208f034cf64.png">
