### PR TITLE
Revert "Bump screenfull from 3.3.3 to 5.1.0"

### DIFF
--- a/packages/canvas-panel-core/package.json
+++ b/packages/canvas-panel-core/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.3.2",
     "react-draggable": "^4.0.0",
     "react-measure": "^2.0.2",
-    "screenfull": "^5.1.0",
+    "screenfull": "^3.3.2",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13282,10 +13282,10 @@ schema-utils@^2.6.5:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-screenfull@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.1.0.tgz#85c13c70f4ead4c1b8a935c70010dfdcd2c0e5c8"
-  integrity sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA==
+screenfull@^3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-3.3.3.tgz#8cf7e706aceac2e75131aadcb81b622acfe11d39"
+  integrity sha512-DzYUuXr+OV2BDvYXaYzlYgJd4WXZZ2CW5NFC7Kw6TUCpzXJAx4MwlVD6CH+Mu6fi8rfAQIQfqdFZ4jtDsEkWig==
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
Reverts digirati-co-uk/canvas-panel#727